### PR TITLE
chore: bump near crates to 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ url = { version = "2", features = ["serde"] }
 
 near-crypto = "0.35"
 near-primitives = "0.35"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump-near-crates-0.35" }
+near-jsonrpc-client = "0.21"
 near-jsonrpc-primitives = "0.35"
 
 near-token = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.35.0-rc.5"
-near-primitives = "0.35.0-rc.5"
+near-crypto = "0.35"
+near-primitives = "0.35"
 near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump-near-crates-0.35" }
-near-jsonrpc-primitives = "0.35.0-rc.5"
+near-jsonrpc-primitives = "0.35"
 
 near-token = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.34"
-near-primitives = "0.34"
-near-jsonrpc-client = "0.20"
-near-jsonrpc-primitives = "0.34"
+near-crypto = "0.35.0-rc.5"
+near-primitives = "0.35.0-rc.5"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump-near-crates-0.35" }
+near-jsonrpc-primitives = "0.35.0-rc.5"
 
 near-token = "0.3.0"
 


### PR DESCRIPTION
- Bump near-crypto, near-primitives, near-jsonrpc-primitives from 0.34 to 0.35
- Bump near-jsonrpc-client from 0.20 to 0.21

Unblocks:
- near/near-cli-rs#580