### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-socialdb-client"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps package version from 0.14.0 to 0.15.0 since the near-* crates 0.34 → 0.35 update (#39) is a breaking change for downstream consumers
- Closed the release-plz 0.14.1 PR (#40) so it can regenerate with the correct version

## Test plan
- [ ] CI passes
- [ ] release-plz picks up the new version after merge