### PR TITLE
chore: bump nearcore crates to 0.36 (2.12 / protocol 84)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.36.0-rc.2"
-near-primitives = "0.36.0-rc.2"
+near-crypto = "0.36.0"
+near-primitives = "0.36.0"
 near-jsonrpc-client = "0.21"
-near-jsonrpc-primitives = "0.36.0-rc.2"
+near-jsonrpc-primitives = "0.36.0"
 
 near-token = "0.3.0"
 
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["full"] }
 
 # RC-only: near-jsonrpc-client is not yet published at 0.36.x. Pull the 2.12 bump
 # from its sibling branch (near/near-jsonrpc-client-rs#189), which carries
-# near-jsonrpc-client at 0.36.0-rc.2. Remove before release once
+# near-jsonrpc-client at 0.36.0. Remove before release once
 # near-jsonrpc-client 0.36.x is published to crates.io.
 [patch.crates-io]
 near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump/nearcore-2.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,20 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.35"
-near-primitives = "0.35"
+near-crypto = "0.36.0-rc.2"
+near-primitives = "0.36.0-rc.2"
 near-jsonrpc-client = "0.21"
-near-jsonrpc-primitives = "0.35"
+near-jsonrpc-primitives = "0.36.0-rc.2"
 
 near-token = "0.3.0"
 
 [dev-dependencies]
 httpmock = "0.7.0"
 tokio = { version = "1", features = ["full"] }
+
+# RC-only: near-jsonrpc-client is not yet published at 0.36.x. Pull the 2.12 bump
+# from its sibling branch (near/near-jsonrpc-client-rs#189), which carries
+# near-jsonrpc-client at 0.36.0-rc.2. Remove before release once
+# near-jsonrpc-client 0.36.x is published to crates.io.
+[patch.crates-io]
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump/nearcore-2.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,3 @@ near-token = "0.3.0"
 [dev-dependencies]
 httpmock = "0.7.0"
 tokio = { version = "1", features = ["full"] }
-
-# RC-only: near-jsonrpc-client is not yet published at 0.36.x. Pull the 2.12 bump
-# from its sibling branch (near/near-jsonrpc-client-rs#189), which carries
-# near-jsonrpc-client at 0.36.0. Remove before release once
-# near-jsonrpc-client 0.36.x is published to crates.io.
-[patch.crates-io]
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", branch = "bump/nearcore-2.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bos-cli-rs/near-socialdb-client-rs"
 description = "near-socialdb-client-rs is crate for work with data in near-social."
+rust-version = "1.93"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Bumps the nearcore dependencies (`near-crypto`, `near-primitives`, `near-jsonrpc-primitives`) from 0.35 to 0.36 for 2.12, which is now live on mainnet (protocol 84). Builds against the published `near-jsonrpc-client` 0.21.1, so the pre-publish `[patch.crates-io]` git pin is removed.
