### PR TITLE
ci: use nearprotocol-ci bot token for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Swaps release-plz's `GITHUB_TOKEN` for the `NEARPROTOCOL_CI_PR_ACCESS` org token (the nearprotocol-ci bot), matching near-sdk/near-cli/near-sandbox.

Right now the "chore: release" PRs are created with the default `GITHUB_TOKEN`, so CI doesn't fire on them and we have to close/reopen to trigger checks. Using the bot token makes those PRs bot-authored and dispatches CI automatically.