### PR TITLE
feat: support nearcore 2.13 / post-quantum ML-DSA-65 keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.37.0-rc.2"
-near-primitives = "0.37.0-rc.2"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e" }
-near-jsonrpc-primitives = "0.37.0-rc.2"
+near-crypto = "=0.37.0-rc.2"
+near-primitives = "=0.37.0-rc.2"
+near-jsonrpc-client = "=0.22.0-rc.1"
+near-jsonrpc-primitives = "=0.37.0-rc.2"
 
 near-token = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.36.0"
-near-primitives = "0.36.0"
-near-jsonrpc-client = "0.21"
-near-jsonrpc-primitives = "0.36.0"
+near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95" }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
 
 near-token = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95" }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-crypto = "0.37.0-rc.1"
+near-primitives = "0.37.0-rc.1"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d" }
+near-jsonrpc-primitives = "0.37.0-rc.1"
 
 near-token = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "0.37.0-rc.1"
-near-primitives = "0.37.0-rc.1"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d" }
-near-jsonrpc-primitives = "0.37.0-rc.1"
+near-crypto = "0.37.0-rc.2"
+near-primitives = "0.37.0-rc.2"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e" }
+near-jsonrpc-primitives = "0.37.0-rc.2"
 
 near-token = "0.3.0"
 


### PR DESCRIPTION
Pins the near-* dependencies to nearcore's unreleased `2.13-release` branch (rev `46483c8d45579dd89faa3bd47317d4c563bcde10`) and `near-jsonrpc-client` to its `pq/nearcore-2.13` branch (rev `5f5d150d47315745945fba7672bf8c90c5bf7f95`), in order to pick up post-quantum ML-DSA-65 key support. This is needed so that near-cli-rs can git-pin this branch for its post-quantum feature.

## Changes
- `near-crypto`, `near-primitives`, `near-jsonrpc-primitives` -> git deps on nearcore `2.13-release` (rev 46483c8d); version field dropped since the branch crates are version 0.0.0.
- `near-jsonrpc-client` -> git dep on near-jsonrpc-client-rs branch `pq/nearcore-2.13` (rev 5f5d150d).
- `near-token` and all other deps left untouched.

## API changes adapted
None. The 2.12 -> 2.13 near-primitives / near-crypto API changes (e.g. the new `QueryRequest::ViewState` `after_key`/`limit` fields and the `AccountId::is_sub_account_of` signature change) do not touch any API surface this crate uses, so no source changes were required. The existing `QueryRequest::CallFunction` / `ViewAccessKey` and `AccessKeyPermissionView::{FunctionCall, FullAccess}` usages compile unchanged against 2.13.

## Status
- `cargo build --all-features --all-targets`: pass
- `cargo test --all-features`: pass (5/5)
- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass

DRAFT — depends on unreleased nearcore 2.13 plus the near-jsonrpc-client-rs draft PR #190. Will switch back to published crates.io versions once nearcore 2.13 is released.