### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/near/near-socialdb-client-rs/compare/v0.16.0-rc.1...v0.16.0) - 2026-07-09
+
+### Other
+
+- pin to nearcore 2.13.0 stable ([#51](https://github.com/near/near-socialdb-client-rs/pull/51))
+
 ## [0.16.0](https://github.com/near/near-socialdb-client-rs/compare/v0.15.1...v0.16.0) - 2026-07-09
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `near-socialdb-client`: 0.16.0-rc.1 -> 0.16.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.16.0](https://github.com/near/near-socialdb-client-rs/compare/v0.16.0-rc.1...v0.16.0) - 2026-07-09

### Other

- pin to nearcore 2.13.0 stable ([#51](https://github.com/near/near-socialdb-client-rs/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).