### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.16.0-rc.1](https://github.com/near/near-socialdb-client-rs/compare/v0.15.1...v0.16.0-rc.1) - 2026-07-02
+## [0.16.0](https://github.com/near/near-socialdb-client-rs/compare/v0.15.1...v0.16.0) - 2026-07-09
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-socialdb-client"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 edition = "2021"
 authors = ["FroVolod <frol_off@meta.ua>", "frol <frolvlad@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 url = { version = "2", features = ["serde"] }
 
-near-crypto = "=0.37.0-rc.2"
-near-primitives = "=0.37.0-rc.2"
-near-jsonrpc-client = "=0.22.0-rc.1"
-near-jsonrpc-primitives = "=0.37.0-rc.2"
+near-crypto = "0.37.0"
+near-primitives = "0.37.0"
+near-jsonrpc-client = "0.22.0"
+near-jsonrpc-primitives = "0.37.0"
 
 near-token = "0.3.0"
 


### PR DESCRIPTION
nearcore 2.13.0 is on crates.io. This swaps the RC pins to stable and cuts near-socialdb-client 0.16.0:

- `near-crypto`, `near-primitives`, `near-jsonrpc-primitives`: `=0.37.0-rc.2` -> `0.37.0`
- `near-jsonrpc-client`: `=0.22.0-rc.1` -> `0.22.0`
- crate version `0.16.0-rc.1` -> `0.16.0`

**Draft:** the build is gated on `near-jsonrpc-client 0.22.0` publishing (part of the 2.13.0 stable cascade). Ready to merge once that lands.